### PR TITLE
Mamba 8.4

### DIFF
--- a/stage2/main.c
+++ b/stage2/main.c
@@ -446,6 +446,9 @@ LV2_SYSCALL2(int64_t, syscall8, (u64 function, u64 param1, u64 param2, u64 param
 					return ENOSYS;
 					#endif
 					break;
+				case PS3MAPI_OPCODE_PROC_PAGE_FREE:
+					return ps3mapi_process_page_free((process_id_t)param2, param3, (u64 *)param4);
+					break;
 				//----------
 				//MODULE
 				//----------

--- a/stage2/ps3mapi_core.h
+++ b/stage2/ps3mapi_core.h
@@ -56,10 +56,12 @@ int ps3mapi_get_current_process(process_t process);
 #define PS3MAPI_OPCODE_GET_PROC_MEM					0x0031
 #define PS3MAPI_OPCODE_SET_PROC_MEM					0x0032
 #define PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE			0x0033
+#define PS3MAPI_OPCODE_PROC_PAGE_FREE				0x0034
 
 int ps3mapi_set_process_mem(process_id_t pid, u64 addr, char *buf, int size);
 int ps3mapi_get_process_mem(process_id_t pid, u64 addr, char *buf, int size);
-int ps3mapi_process_page_allocate(process_id_t pid, u64 size, u64 page_size, u64 flags, u64 is_executable, u64 *page_address); // TheRouletteBoi
+int ps3mapi_process_page_allocate(process_id_t pid, u64 size, u64 page_size, u64 flags, u64 is_executable, u64 *page_table); // TheRouletteBoi
+int ps3mapi_process_page_free(process_id_t pid, u64 flags, u64 *page_table);
 
 //-----------------------------------------------
 //MODULES


### PR DESCRIPTION
- Modify ps3mapi_process_page_allocate to use page_table as input and output process and kernel page_address mapping that has been allocated
- Add ps3mapi_process_page_free which takes page_table (the process/kernel page_address mappping) and frees it